### PR TITLE
Initial work on saving long urls with custom keys

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -25,17 +25,17 @@ _commander2['default'].option('-p, --port <port>', 'Set port. Default: ' + defau
 
 _commander2['default'].command('init').description('Initialize a project in current directory').action(_libManager2['default'].init);
 
-_commander2['default'].command('add [url]').description('Add a new endpoint').action(_libManager2['default'].add);
+_commander2['default'].command('add [url]').description('Add a new endpoint').option('-k, --key <key>', 'Add custom key to refer to endpont. Defaults to url').action(_libManager2['default'].add);
 
 _commander2['default'].command('list').description('List all endpoint versions').action(_libManager2['default'].list);
 
 _commander2['default'].command('fetch').description('Fetch and store a new version for each endpoint').action(_libManager2['default'].fetch);
 
-_commander2['default'].command('rollback [endpoint]').description('Rollback the endpoint\'s current version').action(_libManager2['default'].rollback);
+_commander2['default'].command('rollback [endpoint]').description("Rollback the endpoint's current version").action(_libManager2['default'].rollback);
 
-_commander2['default'].command('remove [endpoint]').description('Remove the endpoint and all its versions').action(_libManager2['default'].remove);
+_commander2['default'].command('remove [endpoint]').description("Remove the endpoint and all its versions").action(_libManager2['default'].remove);
 
-_commander2['default'].command('diff [endpoint] [v1] [v2]').description('Diff versions. With no version numbers, \n' + 'diffs the current version with the previous').action(_libManager2['default'].diff);
+_commander2['default'].command('diff [endpoint] [v1] [v2]').description("Diff versions. With no version numbers, \n" + "diffs the current version with the previous").action(_libManager2['default'].diff);
 
 _commander2['default'].command('serve').description('Serve local versions').action(_libServer2['default']);
 

--- a/dist/lib/config/index.js
+++ b/dist/lib/config/index.js
@@ -10,7 +10,7 @@ function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj;
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-function _defineProperty(obj, key, value) { return Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 var _path = require('path');
 
@@ -25,7 +25,7 @@ var _defaults = require('../defaults');
 var defaults = _interopRequireWildcard(_defaults);
 
 var defaultConfigData = {
-  'endpoints': _defineProperty({}, defaults.port, (_defaults$port = {}, _defineProperty(_defaults$port, defaults.action, []), _defineProperty(_defaults$port, 'default', true), _defaults$port))
+  "endpoints": _defineProperty({}, defaults.port, (_defaults$port = {}, _defineProperty(_defaults$port, defaults.action, []), _defineProperty(_defaults$port, "default", true), _defaults$port))
 };
 
 exports.defaultConfigData = defaultConfigData;
@@ -66,7 +66,7 @@ exports['default'] = function (projectPath) {
       if (exists) {
         cb();
       } else if (err) {
-        cb({ message: 'Error creating project config', data: err });
+        cb({ message: "Error creating project config", data: err });
       } else {
         _utils2['default'].writeJsonFile(configPath, defaultConfigData, function (err) {
           if (err) {
@@ -320,7 +320,7 @@ exports['default'] = function (projectPath) {
 
     read(function (err, configData) {
       if (err) {
-        cb({ message: 'JSON config is invalid.' });
+        cb({ message: "JSON config is invalid." });
         return;
       }
 

--- a/dist/lib/manager.js
+++ b/dist/lib/manager.js
@@ -22,9 +22,9 @@ exports['default'] = {
   init: function init() {
     _project2['default'].init(function (err) {
       if (err) {
-        console.log('Error initializing project.', err.message);
+        console.log("Error initializing project.", err.message);
       } else {
-        console.log('Project initialized');
+        console.log("Project initialized");
       }
     });
   },
@@ -32,9 +32,12 @@ exports['default'] = {
   add: function add(url, opts) {
     if (!url || !url.length) return;
 
-    _project2['default'].addEndpoint(url, options(opts), function (err) {
+    var addOptions = options(opts);
+    addOptions.key = opts.key;
+
+    _project2['default'].addEndpoint(url, addOptions, function (err) {
       if (err) {
-        console.log('Error adding endpoint.', err.message);
+        console.log("Error adding endpoint.", err.message);
       } else {
         console.log('Endpoint added');
       }
@@ -44,19 +47,19 @@ exports['default'] = {
   fetch: function fetch() {
     _project2['default'].fetchVersions(function (err) {
       if (err) {
-        console.log('Error fetching new versions.', err.message);
+        console.log("Error fetching new versions.", err.message);
       }
     }, function (item) {
-      console.log('Updating', item.url, 'for port', item.port);
+      console.log("Updating", item.url, "for port", item.port);
     }, function (url) {
-      console.log('Could not update', url);
+      console.log("Could not update", url);
     });
   },
 
   list: function list() {
     _project2['default'].itemize(function (err, items) {
       if (err) {
-        console.log('Error getting list.', err.message);
+        console.log("Error getting list.", err.message);
       } else {
         items.forEach(function (item) {
           if (!item) return;
@@ -92,11 +95,11 @@ exports['default'] = {
 
     _project2['default'].rollbackVersion(endpoint, options(opts), function (err) {
       if (err) {
-        console.log('Error rolling back.', err.message);
+        console.log("Error rolling back.", err.message);
         return;
       }
 
-      console.log('Rolled back endpoint');
+      console.log("Rolled back endpoint");
     });
   },
 

--- a/dist/lib/project.js
+++ b/dist/lib/project.js
@@ -103,6 +103,13 @@ function getRoot(cb, dots) {
 }
 
 function addEndpoint(url, opts, cb) {
+
+  var hasCustomKey = opts.key ? opts.key.length > 0 : false;
+  if (!hasCustomKey && url.length > 255) {
+    cb({ message: 'URL is too long. Supply a custom key using the --key option' });
+    return;
+  }
+
   if (!validOptions(opts)) {
     cb({ message: 'Invalid port or action' });
     return;
@@ -114,6 +121,7 @@ function addEndpoint(url, opts, cb) {
         cb(err);return;
       }
 
+      info.key = opts.key;
       storage.endpoints.create(info.url, info, function (err) {
         if (err) {
           cb(err);return;

--- a/dist/lib/storage/endpoints.js
+++ b/dist/lib/storage/endpoints.js
@@ -60,8 +60,7 @@ exports['default'] = function (storagePath) {
     opts = opts || {};
     var port = opts.port || defaults.port;
     var action = opts.action || defaults.action;
-    var name = _utilsJs2['default'].endpointNameFromPath(endpoint);
-
+    var name = _utilsJs2['default'].endpointNameFromPath(endpoint, opts);
     return _path2['default'].join(storagePath, port, action, name);
   }
 

--- a/dist/lib/utils.js
+++ b/dist/lib/utils.js
@@ -36,7 +36,13 @@ function cleanUrl(url) {
   return url.replace(/^https?:\/\//, '');
 }
 
-function endpointNameFromPath(path) {
+function endpointNameFromPath(path, opts) {
+  opts = opts || {};
+
+  if (opts.key && opts.key.length > 0) {
+    return opts.key;
+  }
+
   return encodeURIComponent(cleanUrl(path));
 }
 
@@ -96,22 +102,16 @@ function findIndexBy(arr, opts) {
     if (typeof opts === 'function') {
       return opts(item);
     } else {
-      var _ret = (function () {
-        var doesMatch = keys.length > 0;
+      var doesMatch = keys.length > 0;
 
-        keys.forEach(function (key) {
-          if (opts[key] !== item[key]) {
-            doesMatch = false;
-            return;
-          }
-        });
+      keys.forEach(function (key) {
+        if (opts[key] !== item[key]) {
+          doesMatch = false;
+          return;
+        }
+      });
 
-        return {
-          v: doesMatch
-        };
-      })();
-
-      if (typeof _ret === 'object') return _ret.v;
+      return doesMatch;
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ program
 program
   .command('add [url]')
   .description('Add a new endpoint')
+  .option('-k, --key <key>', 'Add custom key to refer to endpont. Defaults to url')
   .action(manager.add)
 
 program

--- a/src/lib/manager.js
+++ b/src/lib/manager.js
@@ -17,7 +17,10 @@ export default {
   add: function(url, opts) {
     if (!url || !url.length) return
 
-    project.addEndpoint(url, options(opts), err => {
+    var addOptions = options(opts)
+    addOptions.key = opts.key
+
+    project.addEndpoint(url, addOptions, err => {
       if (err) {
         console.log("Error adding endpoint.", err.message)
       } else {

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -69,6 +69,13 @@ function getRoot(cb, dots) {
 }
 
 function addEndpoint(url, opts, cb) {
+
+  var hasCustomKey = opts.key ? opts.key.length > 0 : false
+  if (!hasCustomKey && url.length > 255) {
+    cb({message: 'URL is too long. Supply a custom key using the --key option'})
+    return
+  }
+
   if (!validOptions(opts)) {
     cb({message: 'Invalid port or action'})
     return
@@ -78,6 +85,7 @@ function addEndpoint(url, opts, cb) {
     config.addEndpoint(url, opts, (err, info) => {
       if (err) { cb(err); return }
 
+      info.key = opts.key
       storage.endpoints.create(info.url, info, err => {
         if (err) { cb(err); return }
 

--- a/src/lib/storage/endpoints.js
+++ b/src/lib/storage/endpoints.js
@@ -36,8 +36,7 @@ export default function (storagePath) {
     opts = opts || {}
     const port = opts.port || defaults.port
     const action = opts.action || defaults.action
-    const name = utils.endpointNameFromPath(endpoint)
-
+    const name = utils.endpointNameFromPath(endpoint, opts)
     return path.join(storagePath, port, action, name)
   }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -18,7 +18,13 @@ function cleanUrl(url) {
   return url.replace(/^https?:\/\//, '')
 }
 
-function endpointNameFromPath(path) {
+function endpointNameFromPath(path, opts) {
+  opts = opts || {}
+
+  if (opts.key && opts.key.length > 0) {
+    return opts.key
+  }
+
   return encodeURIComponent(cleanUrl(path))
 }
 

--- a/test/lib/project.js
+++ b/test/lib/project.js
@@ -154,6 +154,22 @@ describe('controller: project', () => {
       beforeEach(project.init)
       const config = configFactory.default(process.cwd())
 
+      it('returns an error if filename is too long', done => {
+        var tooLong = "x".repeat(256)
+        project.addEndpoint(tooLong, {}, err => {
+          assert.isObject(err)
+          done()
+        })
+      })
+
+      it('doesnt return an error if filename is too long and custom key is provided', done => {
+        var tooLong = "x".repeat(256)
+        project.addEndpoint(tooLong, {key: "customKey"}, err => {
+          assert.notOk(err)
+          done()
+        })
+      })
+
       it('updates config and creates directory with default options', done => {
         project.addEndpoint(testUrl, {}, err => {
           assert.notOk(err)
@@ -189,6 +205,29 @@ describe('controller: project', () => {
             const projectPath = path.join(process.cwd(), storageFactory.dataDirName)
             const name = utils.endpointNameFromPath(testUrl)
             const filePath = path.join(projectPath, opts.port, opts.action, name)
+
+            assert.fileExists(filePath)
+            done()
+          })
+        })
+      })
+
+      it('creates directory with custom key', done => {
+        const testUrl = 'http://www.someurl.com/api/v1/stuff'
+        const key = "customKey"
+        const opts = {port: '1234', action: 'post', key: key}
+
+        project.addEndpoint(testUrl, opts, err => {
+          assert.notOk(err)
+
+          config.read((err, configData) => {
+            assert.notOk(err)
+            //assert.equal(configData.endpoints['5000'].get.length, 0)
+            //assert.equal(configData.endpoints[opts.port][opts.action].length, 1)
+            //assert.equal(configData.endpoints[opts.port][opts.action][0], key)
+
+            const projectPath = path.join(process.cwd(), storageFactory.dataDirName)
+            const filePath = path.join(projectPath, opts.port, opts.action, key)
 
             assert.fileExists(filePath)
             done()


### PR DESCRIPTION
@jacobmoe 

Complex query params can make some URLs too long to save as a filename in the system.

Ref: http://apple.stackexchange.com/questions/86611/does-os-x-enforce-a-maximum-filename-length-or-character-restriction

Here's some initial work on saving endpoints given a custom key rather than using the url as the filename. 

This is not yet ready. I'm opening this for feedback and some help. I've gotten as far as accepting a custom key from the command line and creating the file path using that key. However, this mapping from key to url needs to be saved in the config file and then read when the file needs to be served. Open to thoughts on this.
