### PR TITLE
Hash urls to allow for caching long file names

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31,11 +31,11 @@ _commander2['default'].command('list').description('List all endpoint versions')
 
 _commander2['default'].command('fetch').description('Fetch and store a new version for each endpoint').action(_libManager2['default'].fetch);
 
-_commander2['default'].command('rollback [endpoint]').description('Rollback the endpoint\'s current version').action(_libManager2['default'].rollback);
+_commander2['default'].command('rollback [endpoint]').description("Rollback the endpoint's current version").action(_libManager2['default'].rollback);
 
-_commander2['default'].command('remove [endpoint]').description('Remove the endpoint and all its versions').action(_libManager2['default'].remove);
+_commander2['default'].command('remove [endpoint]').description("Remove the endpoint and all its versions").action(_libManager2['default'].remove);
 
-_commander2['default'].command('diff [endpoint] [v1] [v2]').description('Diff versions. With no version numbers, \n' + 'diffs the current version with the previous').action(_libManager2['default'].diff);
+_commander2['default'].command('diff [endpoint] [v1] [v2]').description("Diff versions. With no version numbers, \n" + "diffs the current version with the previous").action(_libManager2['default'].diff);
 
 _commander2['default'].command('serve').description('Serve local versions').action(_libServer2['default']);
 

--- a/dist/lib/config/index.js
+++ b/dist/lib/config/index.js
@@ -10,7 +10,7 @@ function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj;
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-function _defineProperty(obj, key, value) { return Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 var _path = require('path');
 
@@ -25,7 +25,7 @@ var _defaults = require('../defaults');
 var defaults = _interopRequireWildcard(_defaults);
 
 var defaultConfigData = {
-  'endpoints': _defineProperty({}, defaults.port, (_defaults$port = {}, _defineProperty(_defaults$port, defaults.action, []), _defineProperty(_defaults$port, 'default', true), _defaults$port))
+  "endpoints": _defineProperty({}, defaults.port, (_defaults$port = {}, _defineProperty(_defaults$port, defaults.action, []), _defineProperty(_defaults$port, "default", true), _defaults$port))
 };
 
 exports.defaultConfigData = defaultConfigData;
@@ -66,7 +66,7 @@ exports['default'] = function (projectPath) {
       if (exists) {
         cb();
       } else if (err) {
-        cb({ message: 'Error creating project config', data: err });
+        cb({ message: "Error creating project config", data: err });
       } else {
         _utils2['default'].writeJsonFile(configPath, defaultConfigData, function (err) {
           if (err) {
@@ -320,7 +320,7 @@ exports['default'] = function (projectPath) {
 
     read(function (err, configData) {
       if (err) {
-        cb({ message: 'JSON config is invalid.' });
+        cb({ message: "JSON config is invalid." });
         return;
       }
 

--- a/dist/lib/manager.js
+++ b/dist/lib/manager.js
@@ -22,9 +22,9 @@ exports['default'] = {
   init: function init() {
     _project2['default'].init(function (err) {
       if (err) {
-        console.log('Error initializing project.', err.message);
+        console.log("Error initializing project.", err.message);
       } else {
-        console.log('Project initialized');
+        console.log("Project initialized");
       }
     });
   },
@@ -34,7 +34,7 @@ exports['default'] = {
 
     _project2['default'].addEndpoint(url, options(opts), function (err) {
       if (err) {
-        console.log('Error adding endpoint.', err.message);
+        console.log("Error adding endpoint.", err.message);
       } else {
         console.log('Endpoint added');
       }
@@ -44,19 +44,19 @@ exports['default'] = {
   fetch: function fetch() {
     _project2['default'].fetchVersions(function (err) {
       if (err) {
-        console.log('Error fetching new versions.', err.message);
+        console.log("Error fetching new versions.", err.message);
       }
     }, function (item) {
-      console.log('Updating', item.url, 'for port', item.port);
+      console.log("Updating", item.url, "for port", item.port);
     }, function (url) {
-      console.log('Could not update', url);
+      console.log("Could not update", url);
     });
   },
 
   list: function list() {
     _project2['default'].itemize(function (err, items) {
       if (err) {
-        console.log('Error getting list.', err.message);
+        console.log("Error getting list.", err.message);
       } else {
         items.forEach(function (item) {
           if (!item) return;
@@ -92,11 +92,11 @@ exports['default'] = {
 
     _project2['default'].rollbackVersion(endpoint, options(opts), function (err) {
       if (err) {
-        console.log('Error rolling back.', err.message);
+        console.log("Error rolling back.", err.message);
         return;
       }
 
-      console.log('Rolled back endpoint');
+      console.log("Rolled back endpoint");
     });
   },
 

--- a/dist/lib/utils.js
+++ b/dist/lib/utils.js
@@ -12,6 +12,10 @@ var _fsExtra = require('fs-extra');
 
 var _fsExtra2 = _interopRequireDefault(_fsExtra);
 
+var _crypto = require('crypto');
+
+var _crypto2 = _interopRequireDefault(_crypto);
+
 var _package = require('../../package');
 
 var _package2 = _interopRequireDefault(_package);
@@ -37,11 +41,7 @@ function cleanUrl(url) {
 }
 
 function endpointNameFromPath(path) {
-  return encodeURIComponent(cleanUrl(path));
-}
-
-function pathFromEndpointName(name) {
-  return decodeURIComponent(name);
+  return _crypto2['default'].createHash('sha256').update(cleanUrl(path)).digest('hex');
 }
 
 function largest(arr) {
@@ -96,22 +96,16 @@ function findIndexBy(arr, opts) {
     if (typeof opts === 'function') {
       return opts(item);
     } else {
-      var _ret = (function () {
-        var doesMatch = keys.length > 0;
+      var doesMatch = keys.length > 0;
 
-        keys.forEach(function (key) {
-          if (opts[key] !== item[key]) {
-            doesMatch = false;
-            return;
-          }
-        });
+      keys.forEach(function (key) {
+        if (opts[key] !== item[key]) {
+          doesMatch = false;
+          return;
+        }
+      });
 
-        return {
-          v: doesMatch
-        };
-      })();
-
-      if (typeof _ret === 'object') return _ret.v;
+      return doesMatch;
     }
   }
 
@@ -228,7 +222,6 @@ function getProp(obj, propPath) {
 exports['default'] = {
   createDirs: createDirs,
   endpointNameFromPath: endpointNameFromPath,
-  pathFromEndpointName: pathFromEndpointName,
   cleanUrl: cleanUrl,
   largest: largest,
   fileExists: fileExists,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,4 +1,5 @@
 import fs from 'fs-extra'
+import crypto from 'crypto'
 
 import packageJson from '../../package'
 import * as defaults from './defaults'
@@ -19,11 +20,7 @@ function cleanUrl(url) {
 }
 
 function endpointNameFromPath(path) {
-  return encodeURIComponent(cleanUrl(path))
-}
-
-function pathFromEndpointName(name) {
-  return decodeURIComponent(name)
+  return crypto.createHash('sha256').update(cleanUrl(path)).digest('hex')
 }
 
 function largest(arr) {
@@ -200,7 +197,6 @@ function getProp(obj, propPath) {
 export default {
   createDirs: createDirs,
   endpointNameFromPath: endpointNameFromPath,
-  pathFromEndpointName: pathFromEndpointName,
   cleanUrl: cleanUrl,
   largest: largest,
   fileExists: fileExists,

--- a/test/lib/project.js
+++ b/test/lib/project.js
@@ -154,6 +154,15 @@ describe('controller: project', () => {
       beforeEach(project.init)
       const config = configFactory.default(process.cwd())
 
+      it('handles long urls', done => {
+        var longUrl = "x".repeat(300)
+        project.addEndpoint(longUrl, {}, err => {
+          assert.notOk(err)
+
+          done()
+        })
+      })
+
       it('updates config and creates directory with default options', done => {
         project.addEndpoint(testUrl, {}, err => {
           assert.notOk(err)


### PR DESCRIPTION
Complex query params can make some URLs too long to save as a filename in the system.

Ref: http://apple.stackexchange.com/questions/86611/does-os-x-enforce-a-maximum-filename-length-or-character-restriction

This hashes the urls when saving them to the filesystem to ensure that we keep under the character limit.
